### PR TITLE
Fix the case inversion bug

### DIFF
--- a/lib/textCaseManipulation.js
+++ b/lib/textCaseManipulation.js
@@ -50,13 +50,10 @@ function swapCase(string) {
 function invertCase(string) {
   // Input: 'Hello World'
   // Output: 'hELLO wORLD'
-
-  function invertCase(string) {
-    
   return typeof string === "string" || string instanceof String ? string?.split("")?.map((char) =>
         char === char.toUpperCase() ? char.toLowerCase() : char.toUpperCase()
       )
-      .join("");
+      .join("") : string;
   }
 
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -119,7 +119,8 @@ describe("invertCase", () => {
   test("Check for String with Newline and Tab Characters", () => {
     expect(invertCase("Hello\n\tWorld")).toBe("hELLO\n\twORLD");
   });
-  
+});
+
 describe("maskPhone", () => {
   test("masks phone number with default visibleDigits", () => {
     const phoneNumber = "1234567890";


### PR DESCRIPTION
### Pull request summary:

Changes made:

 1] Implemented appropriate ternary operator to fix the case inversion code in [`textCaseManipulation.js#L50-L57`](https://github.com/amolbarkale/stringy-core/blob/main/lib/textCaseManipulation.js).
2] Corrected parenthesis bug in "invertCase" test cases in index.test.js





